### PR TITLE
feat: Auth, User 컨트롤러 및 문서화 추가

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/auth/controller/AuthController.java
+++ b/src/main/java/com/undertheriver/sgsg/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.undertheriver.sgsg.auth.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+	@PostMapping("/login")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "code", value = "github-provided-code", required = true, dataType = "String", paramType = "body"),
+	})
+	@ApiResponses(value = {
+		@ApiResponse(code = 404, message = "찾을 수 없는 유저입니다.")
+	})
+	public void login(@RequestBody String code) {
+
+	}
+
+	@DeleteMapping("/logout")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "Authorization", value = "Bearer sgsg-token-value", required = true, dataType = "String", paramType = "header"),
+	})
+	public void logout() {
+	}
+}

--- a/src/main/java/com/undertheriver/sgsg/config/SpringSecurityConfig.java
+++ b/src/main/java/com/undertheriver/sgsg/config/SpringSecurityConfig.java
@@ -11,16 +11,11 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	public void configure(WebSecurity web) throws Exception {
 		web.ignoring()
-			.antMatchers("/css/**",
-				"/js/**",
-				"/img/**",
-				"/lib/**",
+			.antMatchers(
 				"/h2-console/**",
 				"/v2/**",
-				"/webjars/**",
 				"/swagger**",
-				"/swagger-resources/**",
-				"/member/**");
+				"/swagger-resources/**");
 	}
 
 	@Override

--- a/src/main/java/com/undertheriver/sgsg/config/SpringSecurityConfig.java
+++ b/src/main/java/com/undertheriver/sgsg/config/SpringSecurityConfig.java
@@ -2,15 +2,32 @@ package com.undertheriver.sgsg.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @Configuration
 public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
+	public void configure(WebSecurity web) throws Exception {
+		web.ignoring()
+			.antMatchers("/css/**",
+				"/js/**",
+				"/img/**",
+				"/lib/**",
+				"/h2-console/**",
+				"/v2/**",
+				"/webjars/**",
+				"/swagger**",
+				"/swagger-resources/**",
+				"/member/**");
+	}
+
+	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		//@formatter:off
 		http.authorizeRequests()
+			.antMatchers("/api/v1/auth/login").permitAll()
 			.antMatchers("/health").permitAll()
 			.antMatchers("/").permitAll()
 			.anyRequest().authenticated()

--- a/src/main/java/com/undertheriver/sgsg/config/SwaggerConfig.java
+++ b/src/main/java/com/undertheriver/sgsg/config/SwaggerConfig.java
@@ -24,6 +24,7 @@ public class SwaggerConfig {
 	public Docket api() {
 		return new Docket(DocumentationType.SWAGGER_2)
 			.securitySchemes(Lists.newArrayList(apiKey()))
+			.useDefaultResponseMessages(false)
 			.securityContexts(Lists.newArrayList(securityContext()))
 			.select()
 			.apis(RequestHandlerSelectors.any())

--- a/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
+++ b/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.undertheriver.sgsg.user.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@Api(value = "User")
+public class UserController {
+
+	@ApiOperation(value = "회원 탈퇴")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "Authorization", value = "Bearer sgsg-token-value", required = true, dataType = "String", paramType = "header")
+	})
+	@DeleteMapping
+	public void deleteUser() {
+	}
+
+	@ApiOperation(value = "메모비밀번호 변경")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "Authorization", value = "Bearer sgsg-token-value", required = true, dataType = "String", paramType = "header"),
+		@ApiImplicitParam(name = "password", value = "1234", required = true, dataType = "String", paramType = "body")
+	})
+	@PatchMapping
+	public void updateMemoPassword(@RequestBody String password) {
+	}
+
+	@ApiOperation(value = "회원가입")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "code", value = "github-provided-code", required = true, dataType = "String", paramType = "body"),
+		@ApiImplicitParam(name = "password", value = "1234", required = true, dataType = "String", paramType = "body")
+	})
+	@ApiResponses(value = {
+		@ApiResponse(code = 408, message = "회원가입 시간이 초과되었습니다.")
+	})
+	@PostMapping
+	public void signUp(@RequestBody String code, @RequestBody String password) {
+	}
+}


### PR DESCRIPTION
#15

## 변경 사항
- User, Auth 컨트롤러 정의 및 문서화 추가
- 실패 응답시 Json타입으로 정의되어야하는데, 아직 Dto가 만들어지지않아서 임시로 message에 표현함.
- http://localhost:8080/swagger-ui.html#/에서 문서화 확인가능

## 기타
- 

