### PR TITLE
feat: Folder API 추가

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/common/domain/BaseEntity.java
+++ b/src/main/java/com/undertheriver/sgsg/common/domain/BaseEntity.java
@@ -13,8 +13,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 
 @Data
 @MappedSuperclass

--- a/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
@@ -22,15 +22,21 @@ import io.swagger.annotations.ApiResponses;
 @RequestMapping("/api/v1/folders")
 @Api(value = "folder")
 public class FolderController {
-
 	@ApiOperation(value = "폴더 생성")
-	@ApiImplicitParam(name = "title", value = "폴더 이름", required = true, dataType = "String", paramType = "body")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "title", value = "폴더 이름", required = true, dataType = "String", paramType = "body"),
+		@ApiImplicitParam(name = "color", value = "폴더 색깔", required = true, dataType = "String", paramType = "body"),
+		@ApiImplicitParam(name = "order", value = "폴더 순서", required = true, dataType = "Integer", paramType = "body")
+	})
+
 	@ApiResponses(value = {
 		@ApiResponse(code = 201, message = "Location: /api/folders/1"),
 		@ApiResponse(code = 406, message = "폴더는 20개까지 생성 가능합니다")
 	})
 	@PostMapping
-	public void save(@RequestBody String title){}
+	public void save(@RequestBody String title) {
+	}
+
 
 	@ApiOperation("폴더 제목 수정")
 	@ApiImplicitParams({
@@ -38,16 +44,19 @@ public class FolderController {
 		@ApiImplicitParam(name = "title", value = "폴더 이름", required = true, dataType = "String", paramType = "body")
 	})
 	@PutMapping("/{id}")
-	public void update(@PathVariable Long id, @RequestBody String title){}
+	public void update(@PathVariable Long id, @RequestBody String title) {
+	}
 
 	@ApiOperation("폴더 순서 수정")
 	@PutMapping("/order")
-	public void updateOrder(@RequestBody List<Long> ids) {}
+	public void updateOrder(@RequestBody List<Long> ids) {
+	}
 
 	@ApiOperation("폴더 조회")
 	@ApiResponses(
-		@ApiResponse(code = 200, message = "[ { 'id' = 1, 'title' = '...' }, {'id' = 2, 'title' = '...' }, .... ] " )
+		@ApiResponse(code = 200, message = "[ { 'id' = 1, 'title' = '...' }, {'id' = 2, 'title' = '...' }, .... ] ")
 	)
 	@GetMapping
-	public void read() {}
+	public void read() {
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Color.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Color.java
@@ -1,5 +1,5 @@
 package com.undertheriver.sgsg.foler.domain;
 
-public enum Color {
+public enum FolderColor {
 	BLACK,WHITE
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Color.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Color.java
@@ -1,0 +1,5 @@
+package com.undertheriver.sgsg.foler.domain;
+
+public enum Color {
+	BLACK,WHITE
+}

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -8,12 +8,17 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 import com.undertheriver.sgsg.common.domain.BaseEntity;
+import com.undertheriver.sgsg.foler.domain.dto.FolderDto;
 import com.undertheriver.sgsg.memo.domain.Memo;
+import com.undertheriver.sgsg.user.domain.User;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,8 +35,24 @@ public class Folder extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private FolderColor color;
 
-	private Integer order;
+	private Integer position;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id", updatable = false)
+	private User user;
 
 	@OneToMany(mappedBy = "folder")
 	private List<Memo> memos = new ArrayList<>();
+
+	@Builder
+	public Folder(String title, FolderColor color, Integer position, User user) {
+		this.title = title;
+		this.color = color;
+		this.position = position;
+		this.user = user;
+	}
+
+	public void updateTitle(FolderDto.UpdateFolderTitleReq dto) {
+		this.title = dto.getTitle();
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -55,4 +55,14 @@ public class Folder extends BaseEntity {
 	public void updateTitle(FolderDto.UpdateFolderTitleReq dto) {
 		this.title = dto.getTitle();
 	}
+
+	public void updatePosition(FolderDto.UpdateFolderPositionReq dto) {
+		this.position = dto.getPosition();
+	}
+
+	public void update(FolderDto.UpdateFolderReq dto) {
+		this.title = dto.getTitle();
+		this.color = dto.getColor();
+		this.position = dto.getPosition();
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -1,13 +1,22 @@
 package com.undertheriver.sgsg.foler.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
+import com.undertheriver.sgsg.memo.domain.Memo;
+
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Folder {
@@ -18,10 +27,10 @@ public class Folder {
 	private String title;
 
 	@Enumerated(EnumType.STRING)
-	private Color color;
+	private FolderColor color;
 
 	private Integer order;
 
-	// @OneToMany(mappedBy = "folder")
-	// private List<Memo> memos;
+	@OneToMany(mappedBy = "folder")
+	private List<Memo> memos = new ArrayList<>();
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -1,0 +1,27 @@
+package com.undertheriver.sgsg.foler.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Folder {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String title;
+
+	@Enumerated(EnumType.STRING)
+	private Color color;
+
+	private Integer order;
+
+	// @OneToMany(mappedBy = "folder")
+	// private List<Memo> memos;
+}

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -10,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.memo.domain.Memo;
 
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class Folder {
+public class Folder extends BaseEntity {
 	@Id
 	@GeneratedValue
 	private Long id;

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
@@ -1,5 +1,5 @@
 package com.undertheriver.sgsg.foler.domain;
 
 public enum FolderColor {
-	BLACK,WHITE
+	BLACK, WHITE
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
@@ -1,0 +1,59 @@
+package com.undertheriver.sgsg.foler.domain.dto;
+
+import com.undertheriver.sgsg.foler.domain.Folder;
+import com.undertheriver.sgsg.foler.domain.FolderColor;
+import com.undertheriver.sgsg.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FolderDto {
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class CreateFolderReq {
+		private String title;
+		private FolderColor color;
+		private Integer position;
+		private User user;
+
+		@Builder
+		public CreateFolderReq(String title, FolderColor color, Integer position, User user) {
+			this.title = title;
+			this.color = color;
+			this.position = position;
+			this.user = user;
+		}
+
+		public Folder toEntity() {
+			return Folder.builder()
+				.title(this.title)
+				.color(this.color)
+				.position(this.position)
+				.user(this.user)
+				.build();
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class UpdateFolderTitleReq {
+		private Long id;
+		private String title;
+
+		@Builder
+		public UpdateFolderTitleReq(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Folder toEntity() {
+			return Folder.builder()
+				.title(this.title)
+				.build();
+		}
+	}
+
+}

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
@@ -56,4 +56,47 @@ public class FolderDto {
 		}
 	}
 
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class UpdateFolderPositionReq {
+		private Long id;
+		private Integer position;
+
+		@Builder
+		public UpdateFolderPositionReq(Long id, Integer position) {
+			this.id = id;
+			this.position = position;
+		}
+
+		public Folder toEntity() {
+			return Folder.builder()
+				.position(this.position)
+				.build();
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class UpdateFolderReq {
+		private Long id;
+		private String title;
+		private Integer position;
+		private FolderColor color;
+
+		@Builder
+		public UpdateFolderReq(Long id, String title, Integer position, FolderColor color) {
+			this.id = id;
+			this.title = title;
+			this.position = position;
+			this.color = color;
+		}
+
+		public Folder toEntity() {
+			return Folder.builder()
+				.title(this.title)
+				.color(this.color)
+				.position(this.position)
+				.build();
+		}
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -1,0 +1,13 @@
+package com.undertheriver.sgsg.foler.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.undertheriver.sgsg.foler.domain.Folder;
+
+@Repository
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+	List<Folder> findAllByDeletedIsOrDeletedIs(Boolean deleted, Boolean deleted2);
+}

--- a/src/main/java/com/undertheriver/sgsg/memo/controller/MemoController.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/controller/MemoController.java
@@ -1,9 +1,5 @@
 package com.undertheriver.sgsg.memo.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.undertheriver.sgsg.memo.dto.request.CreateMemoRequestDto;
-import com.undertheriver.sgsg.memo.dto.response.ReadMemoResponseDto;
+import com.undertheriver.sgsg.memo.domain.dto.request.CreateMemoRequestDto;
+import com.undertheriver.sgsg.memo.domain.dto.response.ReadMemoResponseDto;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
@@ -1,0 +1,35 @@
+package com.undertheriver.sgsg.memo.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.undertheriver.sgsg.foler.domain.Folder;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo {
+
+	@Id
+	@GeneratedValue
+	private long id;
+
+	private String content;
+
+	private Boolean isSecret;
+
+	private Boolean isFavorite;
+
+	private String thumbnailUrl;
+
+	@ManyToOne
+	@JoinColumn(name = "folder_id", updatable = false)
+	private Folder folder;
+}

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
@@ -6,6 +6,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.foler.domain.Folder;
 
 import lombok.AccessLevel;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Memo {
+public class Memo extends BaseEntity {
 
 	@Id
 	@GeneratedValue

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/dto/request/CreateMemoRequestDto.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/dto/request/CreateMemoRequestDto.java
@@ -1,4 +1,4 @@
-package com.undertheriver.sgsg.memo.dto.request;
+package com.undertheriver.sgsg.memo.domain.dto.request;
 
 import javax.validation.constraints.NotNull;
 

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/dto/response/ReadMemoResponseDto.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/dto/response/ReadMemoResponseDto.java
@@ -1,7 +1,4 @@
-package com.undertheriver.sgsg.memo.dto.response;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+package com.undertheriver.sgsg.memo.domain.dto.response;
 
 import lombok.Getter;
 

--- a/src/main/java/com/undertheriver/sgsg/user/domain/User.java
+++ b/src/main/java/com/undertheriver/sgsg/user/domain/User.java
@@ -1,10 +1,16 @@
 package com.undertheriver.sgsg.user.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import com.undertheriver.sgsg.foler.domain.Folder;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +24,9 @@ public class User {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@OneToMany(mappedBy = "user")
+	private List<Folder> folders = new ArrayList<>();
 
 	@Embedded
 	private UserSecretMemoPassword userSecretMemoPassword;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,23 @@ spring:
   config:
     activate:
       on-profile: production
+
+---
+
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driverClassName: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.MariaDBDialect

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.undertheriver.sgsg.foler.repository;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.undertheriver.sgsg.foler.domain.Folder;
+import com.undertheriver.sgsg.foler.domain.FolderColor;
+import com.undertheriver.sgsg.foler.domain.dto.FolderDto;
+import com.undertheriver.sgsg.user.domain.User;
+import com.undertheriver.sgsg.user.domain.UserRepository;
+
+@SpringBootTest
+class FolderRepositoryTest {
+	@Autowired
+	private FolderRepository folderRepository;
+	@Autowired
+	private UserRepository userRepository;
+
+	Folder undeletedFolder;
+	Folder deletedFolder;
+
+	private static final String TEST_TITLE_VALUE = "테스트 폴더";
+	private static final String TEST_TITLE_VALUE2 = "테스트 폴더2";
+	private static final String TEST_TITLE_VALUE3 = "업데이트 테스트 폴더";
+
+	private static final Integer TEST_POSITION_VALUE = 0;
+	private static final Integer TEST_POSITION_VALUE2 = 1;
+
+	private static final Integer NUMBER_OF_UNDELETED_FOLDERS = 1;
+	private static final Integer NUMBER_OF_FOLDERS = 2;
+
+	@BeforeEach
+	public void beforeEach() {
+		String rawPassword = "1234";
+		User user = new User(rawPassword);
+		user = userRepository.save(user);
+
+		final FolderDto.CreateFolderReq req = FolderDto.CreateFolderReq.builder()
+			.user(user)
+			.title(TEST_TITLE_VALUE)
+			.color(FolderColor.BLACK)
+			.position(TEST_POSITION_VALUE)
+			.build();
+		undeletedFolder = req.toEntity();
+
+		final FolderDto.CreateFolderReq req2 = FolderDto.CreateFolderReq.builder()
+			.user(user)
+			.title(TEST_TITLE_VALUE2)
+			.color(FolderColor.BLACK)
+			.position(TEST_POSITION_VALUE2)
+			.build();
+		deletedFolder = req2.toEntity();
+		deletedFolder.setDeleted(true);
+
+		undeletedFolder = folderRepository.save(undeletedFolder);
+		deletedFolder = folderRepository.save(deletedFolder);
+	}
+
+	@DisplayName("Folder를 조회할 수 있다.")
+	@Test
+	@Order(0)
+	public void read() {
+		System.out.println("READ 먼저");
+		List<Folder> folders = folderRepository.findAll();
+		List<Folder> undeletedFolders = folderRepository.findAllByDeletedIsOrDeletedIs(false, null);
+
+		System.out.println();
+		assertAll(
+			() -> assertThat(folders.size()).isEqualTo(NUMBER_OF_FOLDERS),
+			() -> assertThat(undeletedFolders.size()).isEqualTo(NUMBER_OF_UNDELETED_FOLDERS)
+		);
+	}
+
+	@DisplayName("Folder를 생성할 수 있다.")
+	@Test
+	@Order(1)
+	public void save() {
+		System.out.println("SAVE 먼저");
+		assertAll(
+			() -> assertThat(undeletedFolder.getTitle()).isEqualTo(TEST_TITLE_VALUE)
+		);
+	}
+
+	@DisplayName("Folder 제목을 수정할 수 있다.")
+	@Test
+	@Order(2)
+	public void updateTitle() {
+		System.out.println("UPDATE 먼저");
+		final FolderDto.UpdateFolderTitleReq req = FolderDto.UpdateFolderTitleReq.builder()
+			.id(undeletedFolder.getId())
+			.title(TEST_TITLE_VALUE3)
+			.build();
+
+		Folder beforeFolder = folderRepository.findById(req.getId()).get();
+		String beforeTitle = beforeFolder.getTitle();
+		Folder afterFolder = updateFolderTitle(beforeFolder.getId(), req);
+		String afterTitle = afterFolder.getTitle();
+
+		assertAll(
+			() -> assertThat(beforeTitle).isNotEqualTo(afterTitle)
+		);
+	}
+
+	// TODO: MOVE TO FolderService
+	public Folder updateFolderTitle(Long id, FolderDto.UpdateFolderTitleReq dto) {
+		final Folder folder = folderRepository.findById(id).get();
+		folder.updateTitle(dto);
+		return folder;
+	}
+}


### PR DESCRIPTION
#34

## 변경 사항
- Folder API
  - 로직 구현
  - 테스트 코드 추가
- application.xml 프로퍼티 추가
  - h2-console datasource
  - springboot sql logging 
 

### 작업 예정
- Folder API Controller
- Folder API Service

## 기타
- 코드의 양이 많아져서 일단 중간 리뷰를 위해서 PR을 날립니다.
  - 커밋 단위를 기능 단위로 했으면 리뷰하는데에 부담이 덜했을 것 같은데 제가 신경을 못썼네요 ㅠㅠ 죄송합니다
- save 로직에서 20개 이상일 때는 저장을 못하게 하는 로직을 어떻게 할지 고민입니다.
  - Query 메소드를 사용해서 서브 쿼리를 활용해서 직접 짤지
  - SELECT LIMIT 20 쿼리를 한번 날리고 리스트의 길이가 20이 넘는지 판단 후 save할지 고민입니다.
- UPDATE 관련 로직들을 열심히 짰는데 생각해보니 UPDATE를 위한 페이지를 만들어서 UPDATE를 마친 후 폴더들의 모든 값들을 담은 BODY를 받을 것 같습니다. 그래서 updateFolder라는 메소드로 퉁칠 수 있을 것 같습니다. 스웨거도 수정하겠습니다.
- 2년만에 스프링부트를 하니까 작업 속도가 안나네요 ㅋㅋㅋ;; 

