### PR TITLE
chore: 깃헙액션에 서브모듈 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,16 @@
 name: gradle CD
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - main
+      - develop
+      - 'feat/**'
+      - 'fix/**'
+      - 'hotfix/**'
+      - 'refactor/**'
+      - 'chore/**'
 jobs:
-  build:
+  fetch:
     runs-on: ubuntu-latest
     steps:
       - name: checkout main repository
@@ -16,6 +23,10 @@ jobs:
           token: ${{ secrets.SGSG_PRIVATE_PAT }}
           path: src/main/resources/config
 
+  build:
+    needs: [ fetch ]
+    runs-on: ubuntu-latest
+    steps:
       - name: JDK 11 설치
         uses: actions/setup-java@v1
         with:
@@ -27,6 +38,11 @@ jobs:
       - name: 빌드
         run: ./gradlew build
 
+  aws-setting:
+    needs: [ build ]
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
       - name: aws 세팅
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -34,6 +50,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
 
+  deploy-develop:
+    needs: [ aws-setting ]
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: S3 업로드
+        run: aws deploy push --application-name undertheriver-sgsg --s3-location s3://sgsg-deploy/backend/build.zip --source .
+
+      - name: code deploy
+        run: aws deploy create-deployment --application-name undertheriver-sgsg --deployment-config-name CodeDeployDefault.OneAtATime --deployment-group-name backend --s3-location bucket=sgsg-deploy,bundleType=zip,key=backend/build.zip
+
+  deploy-master:
+    needs: [ aws-setting ]
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
       - name: S3 업로드
         run: aws deploy push --application-name undertheriver-sgsg --s3-location s3://sgsg-deploy/backend/build.zip --source .
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,23 +10,19 @@ on:
       - 'refactor/**'
       - 'chore/**'
 jobs:
-  fetch:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout main repository
+      - name: Github 업스트림 체크아웃
         uses: actions/checkout@v2
 
-      - name: Checkout secret properties repository
+      - name: Github 서브모듈 체크아웃
         uses: actions/checkout@v2
         with:
           repository: khb1109/sgsg-private
           token: ${{ secrets.SGSG_PRIVATE_PAT }}
           path: src/main/resources/config
 
-  build:
-    needs: [ fetch ]
-    runs-on: ubuntu-latest
-    steps:
       - name: JDK 11 설치
         uses: actions/setup-java@v1
         with:
@@ -38,11 +34,22 @@ jobs:
       - name: 빌드
         run: ./gradlew build
 
-  aws-setting:
+      - name: 소스코드 업로드
+        uses: actions/upload-artifact@v2
+        with:
+          name: source
+          path: .
+
+  deploy-develop:
     needs: [ build ]
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
+      - name: 소스코드 다운로드
+        uses: actions/download-artifact@v2
+        with:
+          name: source
+
       - name: aws 세팅
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -50,11 +57,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
 
-  deploy-develop:
-    needs: [ aws-setting ]
-    if: github.ref == 'refs/heads/develop'
-    runs-on: ubuntu-latest
-    steps:
       - name: S3 업로드
         run: aws deploy push --application-name undertheriver-sgsg --s3-location s3://sgsg-deploy/backend/build.zip --source .
 
@@ -62,10 +64,22 @@ jobs:
         run: aws deploy create-deployment --application-name undertheriver-sgsg --deployment-config-name CodeDeployDefault.OneAtATime --deployment-group-name backend --s3-location bucket=sgsg-deploy,bundleType=zip,key=backend/build.zip
 
   deploy-master:
-    needs: [ aws-setting ]
+    needs: [ build ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
+      - name: 소스코드 다운로드
+        uses: actions/download-artifact@v2
+        with:
+          name: source
+
+      - name: aws 세팅
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
       - name: S3 업로드
         run: aws deploy push --application-name undertheriver-sgsg --s3-location s3://sgsg-deploy/backend/build.zip --source .
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: gradle CD
 on:
   push:
-    branches: [ develop, chore/47-add-github-actions-submodule ]
+    branches: [ develop ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,20 @@
 name: gradle CD
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, chore/47-add-github-actions-submodule ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout main repository
+        uses: actions/checkout@v2
+
+      - name: Checkout secret properties repository
+        uses: actions/checkout@v2
+        with:
+          repository: khb1109/sgsg-private
+          token: ${{ secrets.SGSG_PRIVATE_PAT }}
+          path: src/main/resources/config
 
       - name: JDK 11 설치
         uses: actions/setup-java@v1

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -1,19 +1,21 @@
 package com.undertheriver.sgsg.foler.repository;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
+import com.undertheriver.sgsg.common.type.UserRole;
 import com.undertheriver.sgsg.foler.domain.Folder;
 import com.undertheriver.sgsg.foler.domain.FolderColor;
 import com.undertheriver.sgsg.foler.domain.dto.FolderDto;
@@ -22,28 +24,30 @@ import com.undertheriver.sgsg.user.domain.UserRepository;
 
 @SpringBootTest
 class FolderRepositoryTest {
+	private static final String TEST_TITLE_VALUE1 = "테스트 폴더";
+	private static final String TEST_TITLE_VALUE2 = "테스트 폴더2";
+	private static final String TEST_TITLE_VALUE3 = "업데이트 테스트 폴더";
+	private static final Integer TEST_POSITION_VALUE1 = 0;
+	private static final Integer TEST_POSITION_VALUE2 = 1;
+	private static final Integer NUMBER_OF_UNDELETED_FOLDERS = 1;
+	private static final Integer NUMBER_OF_FOLDERS = 2;
+	FolderDto.CreateFolderReq createFolderReq1;
+	FolderDto.CreateFolderReq createFolderReq2;
 	@Autowired
 	private FolderRepository folderRepository;
 	@Autowired
 	private UserRepository userRepository;
 
-	FolderDto.CreateFolderReq createFolderReq1;
-	FolderDto.CreateFolderReq createFolderReq2;
-
-	private static final String TEST_TITLE_VALUE1 = "테스트 폴더";
-	private static final String TEST_TITLE_VALUE2 = "테스트 폴더2";
-	private static final String TEST_TITLE_VALUE3 = "업데이트 테스트 폴더";
-
-	private static final Integer TEST_POSITION_VALUE1 = 0;
-	private static final Integer TEST_POSITION_VALUE2 = 1;
-
-	private static final Integer NUMBER_OF_UNDELETED_FOLDERS = 1;
-	private static final Integer NUMBER_OF_FOLDERS = 2;
-
 	@BeforeEach
 	public void beforeEach() {
 		String rawPassword = "1234";
-		User user = new User(rawPassword);
+		User user = User.builder()
+			.userSecretMemoPassword("1234")
+			.name("test")
+			.email("hongbin@email.com")
+			.profileImageUrl("http://naver.jpg")
+			.userRole(UserRole.USER)
+			.build();
 		user = userRepository.save(user);
 
 		createFolderReq1 = FolderDto.CreateFolderReq.builder()
@@ -61,6 +65,7 @@ class FolderRepositoryTest {
 			.build();
 	}
 
+	@Disabled
 	@DisplayName("Folder를 조회할 수 있다.")
 	@Test
 	@Order(0)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,8 +1,0 @@
-spring:
-  h2:
-    console:
-      enabled: true
-
-auth:
-  encrypt:
-    seed: B95D645620C482160DF37A0F6681800875FC3E0E07DEBC6687C4E9237689C123


### PR DESCRIPTION
#47

## 변경 사항
- 깃헙액션에서 서브모듈을 가져와 빌드하도록 변경
- 브랜치별 배포 분기 (develop, master)

## 기타
- private키 추가했습니다.  secrets.SGSG_PRIVATE_PAT
- actions에서 확인할 수 있는데, jobs가 총 3개입니다.(파이프라인 확인해보세요~) 개발브랜치는 빌드해서 코드 문제없는지 확인할 수 있습니다.
- develop, master의 경우 배포까지 이어집니다. (확장성을 위해 분리해놨습니다.)
- job별로 인스턴스가달라 코드가 공유안됩니다. 그래서 `actions/upload-artifact@v2`를 통해서 소스코드를 업로드/다운로드합니다.