### PR TITLE
feat: 폴더 다음 색상 API 구현

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
@@ -66,8 +66,9 @@ public class FolderController {
 
 	@ApiOperation("다음 폴더 색상 조회")
 	@GetMapping("/color")
-	public ResponseEntity<FolderDto.GetNextFolderColorRes> getNextFolderColor(@RequestParam Integer order) {
-		FolderDto.GetNextFolderColorRes res =  folderService.getNextColor(order);
+	public ResponseEntity<FolderDto.GetNextFolderColorRes> getNextFolderColor(
+		@LoginUser CurrentUser currentUser) {
+		FolderDto.GetNextFolderColorRes res = folderService.getNextColor(currentUser.getId());
 		return ResponseEntity.ok(res);
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/controller/FolderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.undertheriver.sgsg.common.annotation.LoginUser;
@@ -60,6 +61,13 @@ public class FolderController {
 	public ResponseEntity<FolderDto.ReadFolderRes> update(
 		@PathVariable Long id, @RequestBody FolderDto.UpdateFolderReq body) {
 		FolderDto.ReadFolderRes res = folderService.update(id, body);
+		return ResponseEntity.ok(res);
+	}
+
+	@ApiOperation("다음 폴더 색상 조회")
+	@GetMapping("/color")
+	public ResponseEntity<FolderDto.GetNextFolderColorRes> getNextFolderColor(@RequestParam Integer order) {
+		FolderDto.GetNextFolderColorRes res =  folderService.getNextColor(order);
 		return ResponseEntity.ok(res);
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
@@ -7,7 +7,7 @@ public enum FolderColor {
 	PURPLE("#9F69DB"),
 	RED("#E64632");
 
-	String colorCode;
+	private final String colorCode;
 
 	FolderColor(String colorCode) {
 		this.colorCode = colorCode;

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
@@ -7,10 +7,15 @@ public enum FolderColor {
 	PURPLE("#9F69DB"),
 	RED("#E64632");
 
-
 	String colorCode;
 
 	FolderColor(String colorCode) {
 		this.colorCode = colorCode;
+	}
+
+	public static FolderColor getNextColor(int folderRowSize) {
+		FolderColor[] values = FolderColor.values();
+		int nextColorOrdinary = folderRowSize % FolderColor.values().length;
+		return values[nextColorOrdinary];
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
@@ -1,5 +1,16 @@
 package com.undertheriver.sgsg.foler.domain;
 
 public enum FolderColor {
-	BLACK, WHITE
+	BLUE("#2DA5D7"),
+	GREEN("#00A09B"),
+	ORANGE("#F99A42"),
+	PURPLE("#9F69DB"),
+	RED("#E64632");
+
+
+	String colorCode;
+
+	FolderColor(String colorCode) {
+		this.colorCode = colorCode;
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
@@ -82,4 +82,15 @@ public class FolderDto {
 				.build();
 		}
 	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class GetNextFolderColorRes {
+		private FolderColor color;
+
+		@Builder
+		public GetNextFolderColorRes(FolderColor color) {
+			this.color = color;
+		}
+	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
@@ -86,11 +86,11 @@ public class FolderDto {
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class GetNextFolderColorRes {
-		private FolderColor color;
+		private FolderColor nextColor;
 
 		@Builder
-		public GetNextFolderColorRes(FolderColor color) {
-			this.color = color;
+		public GetNextFolderColorRes(FolderColor nextColor) {
+			this.nextColor = nextColor;
 		}
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -11,4 +11,5 @@ import com.undertheriver.sgsg.foler.domain.Folder;
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 	List<Folder> findByUserIdAndDeletedFalseOrDeletedNull(Long userId, Pageable page);
+	Integer countByUserId(Long userId);
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -55,10 +55,12 @@ public class FolderService {
 		return FolderDto.ReadFolderRes.toDto(folder);
 	}
 
-	public FolderDto.GetNextFolderColorRes getNextColor(int order) {
-		FolderColor nextColor = FolderColor.getNextColor(order);
+	@Transactional(readOnly = true)
+	public FolderDto.GetNextFolderColorRes getNextColor(Long userId) {
+		Integer folderCount = folderRepository.countByUserId(userId);
+		FolderColor nextColor = FolderColor.getNextColor(folderCount);
 		return FolderDto.GetNextFolderColorRes.builder()
-			.color(nextColor)
+			.nextColor(nextColor)
 			.build();
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.undertheriver.sgsg.common.dto.PageRequest;
 import com.undertheriver.sgsg.config.PagingConfig;
 import com.undertheriver.sgsg.foler.domain.Folder;
+import com.undertheriver.sgsg.foler.domain.FolderColor;
 import com.undertheriver.sgsg.foler.domain.dto.FolderDto;
 import com.undertheriver.sgsg.foler.repository.FolderRepository;
 
@@ -52,5 +53,12 @@ public class FolderService {
 		final Folder folder = folderRepository.findById(folderId).get();
 		folder.update(dto);
 		return FolderDto.ReadFolderRes.toDto(folder);
+	}
+
+	public FolderDto.GetNextFolderColorRes getNextColor(int order) {
+		FolderColor nextColor = FolderColor.getNextColor(order);
+		return FolderDto.GetNextFolderColorRes.builder()
+			.color(nextColor)
+			.build();
 	}
 }

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -57,12 +57,12 @@ class FolderRepositoryTest {
 
 		createFolderReq1 = FolderDto.CreateFolderReq.builder()
 			.title(TEST_TITLE_VALUE1)
-			.color(FolderColor.BLACK)
+			.color(FolderColor.RED)
 			.build();
 
 		createFolderReq2 = FolderDto.CreateFolderReq.builder()
 			.title(TEST_TITLE_VALUE2)
-			.color(FolderColor.WHITE)
+			.color(FolderColor.RED)
 			.build();
 	}
 
@@ -98,7 +98,7 @@ class FolderRepositoryTest {
 			folderList.add(
 				FolderDto.CreateFolderReq.builder()
 					.title(i + "")
-					.color(FolderColor.BLACK)
+					.color(FolderColor.RED)
 					.build()
 					.toEntity()
 			);

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -141,9 +141,9 @@ class FolderRepositoryTest {
 	@Test
 	public void nextFolderColor() {
 		FolderColor[] colors = FolderColor.values();
+		FolderColor firstColor = FolderColor.values()[0];
 		int folderSize1 = 0;
 		int folderSize2 = colors.length;
-		FolderColor firstColor = FolderColor.values()[0];
 
 		assertAll(
 			() -> assertThat(FolderColor.getNextColor(folderSize1)).isEqualTo(firstColor),

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -137,6 +137,18 @@ class FolderRepositoryTest {
 		);
 	}
 
-}
+	@DisplayName("다음 생성할 폴더 색상을 알려준다.")
+	@Test
+	public void nextFolderColor() {
+		FolderColor[] colors = FolderColor.values();
+		int folderSize1 = 0;
+		int folderSize2 = colors.length;
+		FolderColor firstColor = FolderColor.values()[0];
 
+		assertAll(
+			() -> assertThat(FolderColor.getNextColor(folderSize1)).isEqualTo(firstColor),
+			() -> assertThat(FolderColor.getNextColor(folderSize2)).isEqualTo(firstColor)
+		);
+	}
+}
 


### PR DESCRIPTION
#41

## 변경 사항
- 프론트에서 이미 생성되어 있는 폴더의 개수를 전송 받고 다음 색상을 리턴해줍니다.

## 기타
- save API가 호출 된 후에도 다음 색상을 리턴해줘야하나 고민하고 있습니다. 프론트분들과 의견 조율후에 수정해도 늦지 않을 것 같아서 일단은 save API를 수정하지는 않았습니다. (다음 색상을 리턴 하지 않음)
- URL이 고민입니다. 
  1. "/api/v1/folders/color?order=1" 
  2. "URL: /api/v1/folders/next/color  Body: {folderArrayLength: 1} 
  - 어.. URL 들을 저 후보로 생각하게 된 이유가 있었는데 글로 설명하기가 좀 어렵네요;;


