### PR TITLE
feat: 유저정보, 삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    testCompile('io.rest-assured:rest-assured')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/undertheriver/sgsg/common/exception/ModelNotFoundException.java
+++ b/src/main/java/com/undertheriver/sgsg/common/exception/ModelNotFoundException.java
@@ -1,0 +1,4 @@
+package com.undertheriver.sgsg.common.exception;
+
+public class ModelNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/undertheriver/sgsg/config/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/undertheriver/sgsg/config/resolver/CurrentUserArgumentResolver.java
@@ -10,6 +10,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.undertheriver.sgsg.common.annotation.LoginUser;
 import com.undertheriver.sgsg.common.dto.CurrentUser;
+import com.undertheriver.sgsg.user.domain.User;
 import com.undertheriver.sgsg.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +26,13 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
 		String userId = (String)webRequest.getAttribute("userId", RequestAttributes.SCOPE_REQUEST);
 
-		return userService.findById(Long.valueOf(userId));
+		User user = userService.findById(Long.valueOf(userId));
+		return CurrentUser.builder()
+			.id(user.getId())
+			.name(user.getName())
+			.profileImageUrl(user.getProfileImageUrl())
+			.userRole(user.getUserRole())
+			.build();
 	}
 
 	@Override

--- a/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
+++ b/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
@@ -1,30 +1,56 @@
 package com.undertheriver.sgsg.user.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.undertheriver.sgsg.common.annotation.LoginUser;
+import com.undertheriver.sgsg.common.dto.CurrentUser;
+import com.undertheriver.sgsg.user.controller.dto.UserDto;
+import com.undertheriver.sgsg.user.domain.User;
+import com.undertheriver.sgsg.user.service.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @Api(value = "User")
+@RequiredArgsConstructor
 public class UserController {
+
+	private final UserService userService;
+
+	@ApiOperation(value = "회원 조회")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "Authorization", value = "Bearer sgsg-token-value", required = true, dataType = "String", paramType = "header")
+	})
+	@GetMapping("/me")
+	public ResponseEntity<UserDto.DetailResponse> user(@LoginUser CurrentUser currentUser) {
+		User user = userService.findById(currentUser.getId());
+
+		UserDto.DetailResponse userDetail = new UserDto.DetailResponse(user.getName(),
+			user.getEmail(), user.getProfileImageUrl());
+
+		return ResponseEntity.ok(userDetail);
+	}
 
 	@ApiOperation(value = "회원 탈퇴")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "Authorization", value = "Bearer sgsg-token-value", required = true, dataType = "String", paramType = "header")
 	})
-	@DeleteMapping
-	public void deleteUser() {
+	@DeleteMapping("/me")
+	public ResponseEntity<Void> deleteUser(@LoginUser CurrentUser currentUser) {
+		userService.deleteUser(currentUser.getId());
+
+		return ResponseEntity.ok()
+			.build();
 	}
 
 	@ApiOperation(value = "메모비밀번호 변경")
@@ -34,17 +60,5 @@ public class UserController {
 	})
 	@PatchMapping
 	public void updateMemoPassword(@RequestBody String password) {
-	}
-
-	@ApiOperation(value = "회원가입")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "code", value = "github-provided-code", required = true, dataType = "String", paramType = "body"),
-		@ApiImplicitParam(name = "password", value = "1234", required = true, dataType = "String", paramType = "body")
-	})
-	@ApiResponses(value = {
-		@ApiResponse(code = 408, message = "회원가입 시간이 초과되었습니다.")
-	})
-	@PostMapping
-	public void signUp(@RequestBody String code, @RequestBody String password) {
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/user/controller/dto/UserDto.java
+++ b/src/main/java/com/undertheriver/sgsg/user/controller/dto/UserDto.java
@@ -1,0 +1,18 @@
+package com.undertheriver.sgsg.user.controller.dto;
+
+import com.undertheriver.sgsg.common.type.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDto {
+
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Getter
+	static public class DetailResponse {
+		private String name;
+		private String email;
+		private String profileImageUrl;
+	}
+}

--- a/src/main/java/com/undertheriver/sgsg/user/controller/dto/UserDto.java
+++ b/src/main/java/com/undertheriver/sgsg/user/controller/dto/UserDto.java
@@ -10,7 +10,7 @@ public class UserDto {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	@Getter
-	static public class DetailResponse {
+	public static class DetailResponse {
 		private String name;
 		private String email;
 		private String profileImageUrl;

--- a/src/main/java/com/undertheriver/sgsg/user/domain/User.java
+++ b/src/main/java/com/undertheriver/sgsg/user/domain/User.java
@@ -20,7 +20,6 @@ import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.common.type.UserRole;
 import com.undertheriver.sgsg.foler.domain.Folder;
 import com.undertheriver.sgsg.user.domain.vo.UserSecretMemoPassword;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -78,6 +77,11 @@ public class User extends BaseEntity {
 	public User update(String name, String profileImageUrl) {
 		this.name = name;
 		this.profileImageUrl = profileImageUrl;
+		return this;
+	}
+
+	public User delete() {
+		setDeleted(true);
 		return this;
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/user/service/UserService.java
+++ b/src/main/java/com/undertheriver/sgsg/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.undertheriver.sgsg.user.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.undertheriver.sgsg.common.dto.CurrentUser;
+import com.undertheriver.sgsg.common.exception.ModelNotFoundException;
 import com.undertheriver.sgsg.user.domain.User;
 import com.undertheriver.sgsg.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,18 +15,14 @@ public class UserService {
 
 	private final UserRepository userRepository;
 
-	public CurrentUser findById(Long id) {
+	public User findById(Long id) {
 		return userRepository.findById(id)
-			.map(this::toDto)
-			.orElseThrow(IllegalAccessError::new);
+			.orElseThrow(ModelNotFoundException::new);
 	}
 
-	private CurrentUser toDto(User user) {
-		return CurrentUser.builder()
-			.id(user.getId())
-			.name(user.getName())
-			.profileImageUrl(user.getProfileImageUrl())
-			.userRole(user.getUserRole())
-			.build();
+	public void deleteUser(Long id) {
+		userRepository.findById(id)
+			.map(User::delete)
+			.orElseThrow(ModelNotFoundException::new);
 	}
 }

--- a/src/test/java/com/undertheriver/sgsg/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/undertheriver/sgsg/acceptance/AcceptanceTest.java
@@ -1,0 +1,137 @@
+package com.undertheriver.sgsg.acceptance;
+
+import static io.restassured.RestAssured.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.undertheriver.sgsg.auth.common.JwtProvider;
+import com.undertheriver.sgsg.common.type.UserRole;
+import com.undertheriver.sgsg.user.controller.dto.UserDto;
+import com.undertheriver.sgsg.user.domain.User;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "/query/user.sql")
+@Sql(scripts = "/query/user-delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public abstract class AcceptanceTest {
+
+	@LocalServerPort
+	protected int port;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	private String token;
+
+	protected <T> T getOne(String url, Class<T> classType) {
+		//@formatter:off
+		return
+			given()
+			.when()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.auth()
+					.oauth2(token)
+				.get(url)
+			.then()
+				.statusCode(HttpStatus.SC_OK)
+				.log()
+					.all()
+				.extract()
+					.as(classType);
+		//@formatter:on
+	}
+
+	protected <T> List<T> getAll(String url, Class<T> classType) {
+		//@formatter:off
+		return
+			given()
+			.when()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.auth()
+					.oauth2(token)
+				.get(url)
+			.then()
+				.statusCode(HttpStatus.SC_OK)
+				.log()
+					.all()
+				.extract()
+					.jsonPath()
+						.getList(".", classType);
+		//@formatter:on
+	}
+
+	protected void delete(String url) {
+		//@formatter:off
+		given()
+		.when()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.auth()
+				.oauth2(token)
+			.delete(url)
+		.then()
+			.statusCode(HttpStatus.SC_OK)
+			.log()
+			.all();
+		//@formatter:on
+	}
+
+	@BeforeEach
+	void setUp() {
+		User user = User.builder()
+			.email("test@test.com")
+			.profileImageUrl("http://naver.com/adf.png")
+			.userRole(UserRole.USER)
+			.name("TEST")
+			.userSecretMemoPassword("1234")
+			.build();
+
+		token = jwtProvider.createToken(1L, user.getUserRole());
+
+		if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+			RestAssured.port = port;
+		}
+	}
+
+	@DisplayName("유저 정보 조회")
+	@Test
+	void name() {
+		//@formatter:off
+			System.out.println(token);
+			UserDto.DetailResponse userDetail = given()
+				.when()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.auth()
+				.oauth2(token)
+				.get("/api/v1/users/me")
+				.then()
+				.statusCode(HttpStatus.SC_OK)
+				.log()
+				.all()
+				.extract()
+				.as(UserDto.DetailResponse.class);
+			//@formatter:on
+
+		assertAll(
+			() -> assertThat(userDetail.getName()).isEqualTo("TEST"),
+			() -> assertThat(userDetail.getEmail()).isEqualTo("test@test.com"),
+			() -> assertThat(userDetail.getProfileImageUrl()).isEqualTo("http://naver.com/adf.png")
+		);
+	}
+}
+

--- a/src/test/java/com/undertheriver/sgsg/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/undertheriver/sgsg/acceptance/AcceptanceTest.java
@@ -1,15 +1,11 @@
 package com.undertheriver.sgsg.acceptance;
 
 import static io.restassured.RestAssured.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -18,7 +14,6 @@ import org.springframework.test.context.jdbc.Sql;
 
 import com.undertheriver.sgsg.auth.common.JwtProvider;
 import com.undertheriver.sgsg.common.type.UserRole;
-import com.undertheriver.sgsg.user.controller.dto.UserDto;
 import com.undertheriver.sgsg.user.domain.User;
 import io.restassured.RestAssured;
 
@@ -34,6 +29,23 @@ public abstract class AcceptanceTest {
 	private JwtProvider jwtProvider;
 
 	private String token;
+
+	@BeforeEach
+	void setUp() {
+		User user = User.builder()
+			.email("test@test.com")
+			.profileImageUrl("http://naver.com/adf.png")
+			.userRole(UserRole.USER)
+			.name("TEST")
+			.userSecretMemoPassword("1234")
+			.build();
+
+		token = jwtProvider.createToken(1L, user.getUserRole());
+
+		if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+			RestAssured.port = port;
+		}
+	}
 
 	protected <T> T getOne(String url, Class<T> classType) {
 		//@formatter:off
@@ -88,50 +100,6 @@ public abstract class AcceptanceTest {
 			.log()
 			.all();
 		//@formatter:on
-	}
-
-	@BeforeEach
-	void setUp() {
-		User user = User.builder()
-			.email("test@test.com")
-			.profileImageUrl("http://naver.com/adf.png")
-			.userRole(UserRole.USER)
-			.name("TEST")
-			.userSecretMemoPassword("1234")
-			.build();
-
-		token = jwtProvider.createToken(1L, user.getUserRole());
-
-		if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
-			RestAssured.port = port;
-		}
-	}
-
-	@DisplayName("유저 정보 조회")
-	@Test
-	void name() {
-		//@formatter:off
-			System.out.println(token);
-			UserDto.DetailResponse userDetail = given()
-				.when()
-				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.accept(MediaType.APPLICATION_JSON_VALUE)
-				.auth()
-				.oauth2(token)
-				.get("/api/v1/users/me")
-				.then()
-				.statusCode(HttpStatus.SC_OK)
-				.log()
-				.all()
-				.extract()
-				.as(UserDto.DetailResponse.class);
-			//@formatter:on
-
-		assertAll(
-			() -> assertThat(userDetail.getName()).isEqualTo("TEST"),
-			() -> assertThat(userDetail.getEmail()).isEqualTo("test@test.com"),
-			() -> assertThat(userDetail.getProfileImageUrl()).isEqualTo("http://naver.com/adf.png")
-		);
 	}
 }
 

--- a/src/test/java/com/undertheriver/sgsg/user/controller/UserControllerTest.java
+++ b/src/test/java/com/undertheriver/sgsg/user/controller/UserControllerTest.java
@@ -1,0 +1,31 @@
+package com.undertheriver.sgsg.user.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.undertheriver.sgsg.acceptance.AcceptanceTest;
+import com.undertheriver.sgsg.user.controller.dto.UserDto;
+
+class UserControllerTest extends AcceptanceTest {
+
+	@DisplayName("유저 정보를 조회한다")
+	@Test
+	void name() {
+		UserDto.DetailResponse response = getOne("/api/v1/users/me", UserDto.DetailResponse.class);
+
+		assertAll(
+			() -> assertThat(response.getName()).isEqualTo("TEST"),
+			() -> assertThat(response.getEmail()).isEqualTo("test@test.com"),
+			() -> assertThat(response.getProfileImageUrl()).isEqualTo("http://naver.com/adf.png")
+		);
+	}
+
+	@DisplayName("회원을 탈퇴한다")
+	@Test
+	public void dummy() {
+		delete("/api/v1/users/me");
+	}
+}

--- a/src/test/resources/query/user-delete.sql
+++ b/src/test/resources/query/user-delete.sql
@@ -1,0 +1,2 @@
+delete
+from user;

--- a/src/test/resources/query/user.sql
+++ b/src/test/resources/query/user.sql
@@ -1,0 +1,3 @@
+INSERT INTO user(id, email, profile_image_url, name, user_role)
+values (1, 'test@test.com',
+        'http://naver.com/adf.png', 'TEST', 'USER');


### PR DESCRIPTION
#52

## 변경 사항
- 유저 조회 및 탈퇴기능 구현
- restassured API 레벨 테스트 템플릿 추가
- 다음 PR에서 @LoginUser를 지울거라서 덜 의존적인 코드로 작성하려고했습니다. 조금 모호한 부분이 있을 것 같네요


## 기타
- 

