### PR TITLE
fix: 인증실패, 성공시 처리방식 변경

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/SgsgApplication.java
+++ b/src/main/java/com/undertheriver/sgsg/SgsgApplication.java
@@ -4,9 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+import com.undertheriver.sgsg.config.AppProperties;
 import com.undertheriver.sgsg.config.PagingConfig;
 
-@EnableConfigurationProperties(PagingConfig.class)
+@EnableConfigurationProperties({PagingConfig.class, AppProperties.class})
 @SpringBootApplication
 public class SgsgApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/undertheriver/sgsg/auth/common/JwtProvider.java
+++ b/src/main/java/com/undertheriver/sgsg/auth/common/JwtProvider.java
@@ -3,12 +3,12 @@ package com.undertheriver.sgsg.auth.common;
 import java.util.Base64;
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.undertheriver.sgsg.common.exception.AccessTokenLoadException;
 import com.undertheriver.sgsg.common.exception.ExpiredTokenException;
 import com.undertheriver.sgsg.common.type.UserRole;
+import com.undertheriver.sgsg.config.AppProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -21,12 +21,10 @@ public class JwtProvider {
 	private final String secretKey;
 	private final long validityInMilliseconds;
 
-	public JwtProvider(
-		@Value("${security.jwt.token.secret-key:sample}") String secretKey,
-		@Value("${security.jwt.token.expire-length:300000}") long validityInMilliseconds
-	) {
-		this.secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
-		this.validityInMilliseconds = validityInMilliseconds;
+	public JwtProvider(AppProperties appProperties) {
+		String secret = appProperties.getAuth().getTokenSecret();
+		this.secretKey = Base64.getEncoder().encodeToString(secret.getBytes());
+		this.validityInMilliseconds = appProperties.getAuth().getTokenExpirationMsec();
 	}
 
 	public String createToken(Long userId, UserRole userRole) {

--- a/src/main/java/com/undertheriver/sgsg/common/exception/BadRequestException.java
+++ b/src/main/java/com/undertheriver/sgsg/common/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.undertheriver.sgsg.common.exception;
+
+public class BadRequestException extends RuntimeException {
+	public BadRequestException(String msg) {
+		super(msg);
+	}
+}

--- a/src/main/java/com/undertheriver/sgsg/config/AppProperties.java
+++ b/src/main/java/com/undertheriver/sgsg/config/AppProperties.java
@@ -1,0 +1,41 @@
+package com.undertheriver.sgsg.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "app")
+@Getter
+public class AppProperties {
+	private final Auth auth = new Auth();
+	private final OAuth2 oauth2 = new OAuth2();
+	private final Encrypt encrypt = new Encrypt();
+
+	@Getter
+	@Setter
+	public static class Auth {
+		private String tokenSecret;
+		private long tokenExpirationMsec;
+	}
+
+	@Getter
+	@Setter
+	public static class Encrypt {
+		private String seed;
+	}
+
+	@Getter
+	@Setter
+	public static final class OAuth2 {
+		private List<String> authorizedRedirectUris = new ArrayList<>();
+
+		public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+			this.authorizedRedirectUris = authorizedRedirectUris;
+			return this;
+		}
+	}
+}

--- a/src/main/java/com/undertheriver/sgsg/config/BCryptPasswordEncoderConfig.java
+++ b/src/main/java/com/undertheriver/sgsg/config/BCryptPasswordEncoderConfig.java
@@ -3,19 +3,22 @@ package com.undertheriver.sgsg.config;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class BCryptPasswordEncoderConfig {
 
-	@Value("auth.encrypt.seed")
-	private String encryptSeed;
+	private final AppProperties appProperties;
 
 	@Bean
 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
-		return new BCryptPasswordEncoder(4, new SecureRandom(encryptSeed.getBytes(StandardCharsets.UTF_8)));
+		String seed = appProperties.getEncrypt()
+			.getSeed();
+		return new BCryptPasswordEncoder(4, new SecureRandom(seed.getBytes(StandardCharsets.UTF_8)));
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationFailureHandler.java
@@ -1,24 +1,28 @@
 package com.undertheriver.sgsg.config.security.handler;
 
+import static com.undertheriver.sgsg.config.security.HttpCookieOAuth2AuthorizationRequestRepository.*;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.undertheriver.sgsg.config.security.HttpCookieOAuth2AuthorizationRequestRepository;
-import com.undertheriver.sgsg.util.HttpResponseUtils;
+import com.undertheriver.sgsg.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
 	private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
@@ -26,13 +30,14 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
 
-		response.setStatus(400);
-		AuthenticationResponse responseDto = AuthenticationResponse.builder()
-			.message(exception.getMessage())
-			.build();
-
-		HttpResponseUtils.writeFromJson(response, responseDto);
+		String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue)
+			.orElse(("/"));
+		targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("error", exception.getLocalizedMessage())
+			.build().toUriString();
 
 		authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -87,11 +87,8 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 			.stream()
 			.anyMatch(authorizedRedirectUri -> {
 				URI authorizedURI = URI.create(authorizedRedirectUri);
-				if (authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-					&& authorizedURI.getPort() == clientRedirectUri.getPort()) {
-					return true;
-				}
-				return false;
+				return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+					&& authorizedURI.getPort() == clientRedirectUri.getPort();
 			});
 	}
 }

--- a/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/undertheriver/sgsg/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -1,42 +1,97 @@
 package com.undertheriver.sgsg.config.security.handler;
 
+import static com.undertheriver.sgsg.config.security.HttpCookieOAuth2AuthorizationRequestRepository.*;
+
 import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Optional;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.undertheriver.sgsg.auth.common.JwtProvider;
+import com.undertheriver.sgsg.common.exception.BadRequestException;
+import com.undertheriver.sgsg.common.type.UserRole;
+import com.undertheriver.sgsg.config.AppProperties;
 import com.undertheriver.sgsg.config.security.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.undertheriver.sgsg.config.security.UserPrincipal;
-import com.undertheriver.sgsg.util.HttpResponseUtils;
+import com.undertheriver.sgsg.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Configuration
-public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+@Slf4j
+public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-	private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
-
+	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 	private final JwtProvider jwtProvider;
+	private final AppProperties appProperties;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 
-		UserPrincipal userPrincipal = (UserPrincipal)authentication.getPrincipal();
+		String targetUrl = determineTargetUrl(request, response, authentication);
+		if (response.isCommitted()) {
+			logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+			return;
+		}
+		clearAuthenticationAttributes(request, response);
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
 
-		String token = jwtProvider.createToken(userPrincipal.getId(), userPrincipal.fetchAuthority());
-		AuthenticationResponse responseDto = AuthenticationResponse.builder()
-			.jwtToken(token)
-			.build();
+	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) {
+		Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue);
+		if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
+			throw new BadRequestException("승인되지 않은 URL입니다");
+		}
+		String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+		UserPrincipal principal = (UserPrincipal)authentication.getPrincipal();
 
-		HttpResponseUtils.writeFromJson(response, responseDto);
+		String token = fetchToken(principal);
+		return UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("token", token)
+			.build().toUriString();
+	}
 
-		authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+	private String fetchToken(UserPrincipal principal) {
+		Collection<SimpleGrantedAuthority> authorities = (Collection<SimpleGrantedAuthority>)principal.getAuthorities();
+		String authority = authorities.stream()
+			.findFirst()
+			.orElse(new SimpleGrantedAuthority(UserRole.USER.name()))
+			.getAuthority();
+
+		return jwtProvider.createToken(principal.getId(), UserRole.from(authority));
+	}
+
+	protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+		super.clearAuthenticationAttributes(request);
+		httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+	}
+
+	private boolean isAuthorizedRedirectUri(String uri) {
+		URI clientRedirectUri = URI.create(uri);
+		return appProperties.getOauth2().getAuthorizedRedirectUris()
+			.stream()
+			.anyMatch(authorizedRedirectUri -> {
+				URI authorizedURI = URI.create(authorizedRedirectUri);
+				if (authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+					&& authorizedURI.getPort() == clientRedirectUri.getPort()) {
+					return true;
+				}
+				return false;
+			});
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: auth
+    include: auth, app
   h2:
     console:
       enabled: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: auth
+    include: auth, app
   h2:
     console:
       enabled: true


### PR DESCRIPTION
#38

## 변경 사항
- 카카오톡에 말씀드렸던 것 처럼, 서버에서 인증의 모든사이클을 진행하도록 변경했습니다.
- 핸들러변경한 부분은 기존의 json을 응답하는게 아닌, 프론트엔드가 요청한 redirect url로 302 응답을 보내주게 변경했습니다.

## 기타
- 