### PR TITLE
feat: exception handler 추가

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/core/ApiError.java
+++ b/src/main/java/com/undertheriver/sgsg/core/ApiError.java
@@ -1,4 +1,4 @@
-package com.undertheriver.sgsg.common;
+package com.undertheriver.sgsg.core;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/undertheriver/sgsg/core/ApiResult.java
+++ b/src/main/java/com/undertheriver/sgsg/core/ApiResult.java
@@ -1,4 +1,4 @@
-package com.undertheriver.sgsg.common;
+package com.undertheriver.sgsg.core;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/undertheriver/sgsg/core/GlobalExceptionHandler.java
+++ b/src/main/java/com/undertheriver/sgsg/core/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.undertheriver.sgsg.core;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.undertheriver.sgsg.common.exception.BadRequestException;
+import com.undertheriver.sgsg.common.exception.ModelNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(value = {BadRequestException.class, IllegalArgumentException.class,
+		IndexOutOfBoundsException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ApiResult<?> handleBadRequest(Exception e) {
+		log.info("BadRequest Exception, message: {{}}", e.getMessage());
+		return ApiResult.ERROR(e, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = {AuthenticationException.class})
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public ApiResult<?> unAuthorized(Exception e, HttpServletResponse response) {
+		log.info("AuthenticationException Exception, message: {{}}", e.getMessage());
+		return ApiResult.ERROR(e, HttpStatus.UNAUTHORIZED);
+	}
+
+	@ExceptionHandler(value = {AccessDeniedException.class})
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public ApiResult<?> gone(Exception e) {
+		log.info("AccessDeniedException Exception, message: {{}}", e.getMessage());
+		return ApiResult.ERROR(e, HttpStatus.FORBIDDEN);
+	}
+
+	@ExceptionHandler(value = {ModelNotFoundException.class})
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ApiResult<?> handleNotFound(Exception e) {
+		log.info("ModelNotFoundException Exception, message: {{}}", e.getMessage());
+		return ApiResult.ERROR(e, HttpStatus.NOT_FOUND);
+	}
+
+	@ExceptionHandler(value = {Exception.class})
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ApiResult<?> handleInternalServerError(Exception e) {
+		log.info("Exception, message: {{}}", e.getMessage());
+		return ApiResult.ERROR(e, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
+++ b/src/main/java/com/undertheriver/sgsg/user/controller/UserController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.undertheriver.sgsg.common.ApiResult;
 import com.undertheriver.sgsg.common.annotation.LoginUserId;
+import com.undertheriver.sgsg.core.ApiResult;
 import com.undertheriver.sgsg.user.controller.dto.UserDto;
 import com.undertheriver.sgsg.user.domain.User;
 import com.undertheriver.sgsg.user.service.UserService;


### PR DESCRIPTION
#42

## 변경 사항
- 글로벌 exception hanlder를 추가했습니다. 공통으로 예외날 것들 cotnroller 밖으로 throw하시면 이쪽에서 핸들링해줍니다.

## 기타
- 도메인별로 생기는 CustomException의 경우 도메인 내 패키지에 도메인전용 exception hanlder를 만들어서 사용하시면됩니다. 예를들어 FolderExceptionHandler 등을 만들어서 커스텀Exception만 핸들링하면 좋을 것 같아요.(폴더갯수가 20개가 넘어다거나.. 그런 도메인 내에 발생하는 예외의 경우)

