### PR TITLE
refactor: 도메인 소프트딜리트 적용

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -1,12 +1,8 @@
 package com.undertheriver.sgsg.foler.domain;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -19,38 +15,34 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Where;
+
 import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.foler.domain.dto.FolderDto;
 import com.undertheriver.sgsg.memo.domain.Memo;
 import com.undertheriver.sgsg.user.domain.User;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Table(indexes = @Index(name = "folder_idx_user", columnList = "user"))
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted IS NULL")
 public class Folder extends BaseEntity {
+    @OneToMany(mappedBy = "folder")
+    private final Set<Memo> memos = new LinkedHashSet<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String title;
-
     @Enumerated(EnumType.STRING)
     private FolderColor color;
-
     @ManyToOne
     @JoinColumn(name = "user")
     private User user;
-
-    @OneToMany(mappedBy = "folder")
-    private Set<Memo> memos = new LinkedHashSet<>();
-    
     private Boolean secret;
 
     @Builder

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -13,13 +13,13 @@ import com.undertheriver.sgsg.foler.domain.Folder;
 public interface FolderRepository extends JpaRepository<Folder, Long> {
     @Query(value = "SELECT f FROM Folder f "
         + "JOIN f.memos "
-        + "WHERE f.user.id = :userId AND f.deleted = null OR f.deleted = false "
+        + "WHERE f.user.id = :userId "
         + "GROUP BY f.id "
         + "ORDER BY count(f.id) DESC")
     List<Folder> findAllOrderByMemos(Long userId);
 
     List<Folder> findAllByUserId(Long userId, Sort sort);
 
-    Integer countByUserIdAndDeletedFalseOrDeletedNull(Long userId);
+    Integer countByUserId(Long userId);
 
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -59,7 +59,7 @@ public class FolderService {
     }
 
     private boolean foldersExistMoreThanLimit(Long userId) {
-        Integer folderCount = folderRepository.countByUserIdAndDeletedFalseOrDeletedNull(userId);
+        Integer folderCount = folderRepository.countByUserId(userId);
         return folderCount >= folderLimit;
     }
 
@@ -92,7 +92,7 @@ public class FolderService {
 
     @Transactional(readOnly = true)
     public FolderDto.GetNextFolderColorRes getNextColor(Long userId) {
-        Integer folderCount = folderRepository.countByUserIdAndDeletedFalseOrDeletedNull(userId);
+        Integer folderCount = folderRepository.countByUserId(userId);
         FolderColor nextColor = FolderColor.getNextColor(folderCount);
         return FolderDto.GetNextFolderColorRes.builder()
             .nextColor(nextColor)
@@ -124,7 +124,6 @@ public class FolderService {
 
         folder.unsecret();
     }
-
 
     private void validateFolderPassword(Long userId, String rawPassword) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
@@ -10,10 +10,11 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Where;
+
 import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.foler.domain.Folder;
 import com.undertheriver.sgsg.memo.domain.dto.MemoDto;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted IS NULL")
 public class Memo extends BaseEntity {
 
     @Id
@@ -31,7 +33,7 @@ public class Memo extends BaseEntity {
 
     @Lob
     private String content;
-    
+
     private Boolean favorite;
 
     private String thumbnailUrl;

--- a/src/main/java/com/undertheriver/sgsg/memo/repository/MemoRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/repository/MemoRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import com.undertheriver.sgsg.foler.domain.Folder;
 import com.undertheriver.sgsg.memo.domain.Memo;
 
 @Repository
@@ -14,12 +13,12 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     @Query(value = "SELECT m FROM Memo m "
         + "JOIN Folder f ON f.user.id = :userId "
-        + "WHERE f.id = m.folder.id AND (m.deleted = null OR m.deleted = false) "
+        + "WHERE f.id = m.folder.id "
         + "ORDER BY m.favorite DESC")
     List<Memo> findAllByUser(Long userId);
 
     @Query(value = "SELECT m FROM Memo m "
-        + "WHERE m.folder.id = :folderId AND (m.deleted = null OR m.deleted = false) "
+        + "WHERE m.folder.id = :folderId "
         + "ORDER BY m.favorite DESC")
     List<Memo> findAllByFolder(Long folderId);
 }

--- a/src/main/java/com/undertheriver/sgsg/user/domain/User.java
+++ b/src/main/java/com/undertheriver/sgsg/user/domain/User.java
@@ -17,6 +17,8 @@ import javax.persistence.Index;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Where;
+
 import com.undertheriver.sgsg.common.domain.BaseEntity;
 import com.undertheriver.sgsg.common.type.UserRole;
 import com.undertheriver.sgsg.foler.domain.Folder;
@@ -31,6 +33,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(indexes = @Index(name = "user_idx_email", columnList = "email"))
+@Where(clause = "deleted IS NULL")
 public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/com/undertheriver/sgsg/user/domain/UserApiClient.java
+++ b/src/main/java/com/undertheriver/sgsg/user/domain/UserApiClient.java
@@ -11,8 +11,9 @@ import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import com.undertheriver.sgsg.common.domain.BaseEntity;
+import org.hibernate.annotations.Where;
 
+import com.undertheriver.sgsg.common.domain.BaseEntity;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
     @Index(name = "user_api_clients_idx_oauth_id", columnList = "oauth_id")}
 )
 @NoArgsConstructor
+@Where(clause = "deleted IS NULL")
 public class UserApiClient extends BaseEntity {
 
     @Id

--- a/src/test/java/com/undertheriver/sgsg/learn/UserTest.java
+++ b/src/test/java/com/undertheriver/sgsg/learn/UserTest.java
@@ -1,0 +1,46 @@
+package com.undertheriver.sgsg.learn;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.undertheriver.sgsg.common.type.UserRole;
+import com.undertheriver.sgsg.user.domain.User;
+import com.undertheriver.sgsg.user.domain.UserRepository;
+
+@SpringBootTest
+class UserTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Transactional
+    @Test
+    @DisplayName("연관관계 소프트딜리트 쿼리확인 테스트")
+    void name() {
+
+        User user = User.builder()
+            .email("test@test.com")
+            .profileImageUrl("http://naver.com/adf.png")
+            .userRole(UserRole.USER)
+            .name("TEST")
+            .build();
+
+        User savedUser = userRepository.save(user);
+        savedUser.saveApiClient("testID", "GOOGLE");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        User persistedUser = userRepository.findById(savedUser.getId()).get();
+        System.out.println(persistedUser.getUserApiClients().size());
+    }
+}


### PR DESCRIPTION
#134

## 변경 사항
- 도메인들에 소프트딜리트를 적용했습니다.

## 기타
- 소프트딜리트를 일괄적용하는법을 찾아보니 엔티티 상단에 `@Where(clause = "deleted IS NULL")` 를 붙이면 레포지토리에서 자동으로 적용되더라구요.. 이전에 코드 작성하셨는데..ㅠㅠ 늦게찾아봐서 죄송합니다
- 연관관계를 가져올때도 deleted가 null인 값을 찾아오네요~