### PR TITLE
feat: 폴더 이름 중복 검사

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/common/exception/FolderValidationException.java
+++ b/src/main/java/com/undertheriver/sgsg/common/exception/FolderValidationException.java
@@ -1,0 +1,9 @@
+package com.undertheriver.sgsg.common.exception;
+
+public class FolderValidationException extends RuntimeException {
+    public static final String DUPLICATE_FOLDER_NAME = "이미 존재하는 폴더 이름입니다.";
+    public static final String TOO_MANY_FOLDER = "폴더를 더 이상 생성할 수 없습니다.";
+    public FolderValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -1,6 +1,7 @@
 package com.undertheriver.sgsg.foler.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Integer countByUserId(Long userId);
 
+    Optional<Folder> findFirstByUserIdAndTitle(Long userId, String title);
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -24,6 +24,7 @@ import com.undertheriver.sgsg.user.domain.User;
 import com.undertheriver.sgsg.user.domain.UserRepository;
 import com.undertheriver.sgsg.user.exception.PasswordValidationException;
 
+@Transactional(readOnly = true)
 @Service
 public class FolderService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
@@ -64,9 +65,9 @@ public class FolderService {
         }
     }
 
-    private void validateDuplicate(Long userId, String title) {
-        boolean duplicated = folderRepository.findFirstByUserIdAndTitle(userId, title).isPresent();
-        if (duplicated) {
+    public void validateDuplicate(Long userId, String title) {
+        boolean isDuplicated = folderRepository.findFirstByUserIdAndTitle(userId, title).isPresent();
+        if (isDuplicated) {
             throw new FolderValidationException(DUPLICATE_FOLDER_NAME);
         }
     }
@@ -76,7 +77,6 @@ public class FolderService {
         return folderCount >= folderLimit;
     }
 
-    @Transactional(readOnly = true)
     public List<FolderDto.ReadFolderRes> readAll(Long userId, FolderOrderBy orderBy) {
         if (orderBy == null) {
             orderBy = FolderOrderBy.CREATED_AT;
@@ -88,7 +88,6 @@ public class FolderService {
             .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
     public Folder read(Long folderId) {
         return folderRepository.findById(folderId)
             .orElseThrow(ModelNotFoundException::new);

--- a/src/main/java/com/undertheriver/sgsg/memo/service/MemoService.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/service/MemoService.java
@@ -15,6 +15,7 @@ import com.undertheriver.sgsg.common.exception.FolderValidationException;
 import com.undertheriver.sgsg.common.exception.ModelNotFoundException;
 import com.undertheriver.sgsg.foler.domain.Folder;
 import com.undertheriver.sgsg.foler.repository.FolderRepository;
+import com.undertheriver.sgsg.foler.service.FolderService;
 import com.undertheriver.sgsg.memo.domain.Memo;
 import com.undertheriver.sgsg.memo.domain.dto.MemoDto;
 import com.undertheriver.sgsg.memo.repository.MemoRepository;
@@ -30,6 +31,7 @@ public class MemoService {
     private final MemoRepository memoRepository;
     private final FolderRepository folderRepository;
     private final UserRepository userRepository;
+    private final FolderService folderService;
 
     @Transactional
     public Long save(Long userId, MemoDto.CreateMemoReq body) {
@@ -47,20 +49,13 @@ public class MemoService {
             return getOneFolder(body.getFolderId());
         }
 
-        validateFolderDuplicate(userId, body.getFolderTitle());
+        folderService.validateDuplicate(userId, body.getFolderTitle());
         return folderRepository.save(body.toFolderEntity());
     }
 
     private Folder getOneFolder(Long folderId) {
         return folderRepository.findById(folderId)
             .orElseThrow(ModelNotFoundException::new);
-    }
-
-    private void validateFolderDuplicate(Long userId, String title) {
-        boolean duplicated = folderRepository.findFirstByUserIdAndTitle(userId, title).isPresent();
-        if (duplicated) {
-            throw new FolderValidationException(DUPLICATE_FOLDER_NAME);
-        }
     }
 
     @Transactional
@@ -104,7 +99,7 @@ public class MemoService {
     }
 
     public void favorite(Long userId, Long memoId) {
-        Memo memo =  memoRepository.findById(memoId)
+        Memo memo = memoRepository.findById(memoId)
             .orElseThrow(ModelNotFoundException::new);
 
         validateUserHasMemo(userId, memo);
@@ -113,7 +108,7 @@ public class MemoService {
     }
 
     public void unfavorite(Long userId, Long memoId) {
-        Memo memo =  memoRepository.findById(memoId)
+        Memo memo = memoRepository.findById(memoId)
             .orElseThrow(ModelNotFoundException::new);
 
         validateUserHasMemo(userId, memo);

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.undertheriver.sgsg.foler.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.undertheriver.sgsg.common.type.UserRole;
+import com.undertheriver.sgsg.foler.domain.Folder;
+import com.undertheriver.sgsg.user.domain.User;
+import com.undertheriver.sgsg.user.domain.UserRepository;
+
+@Transactional
+@SpringBootTest
+public class FolderRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FolderRepository folderRepository;
+
+    @DisplayName("유저가 가진 폴더 중 제목이 일치하는 가장 첫 번째 폴더를 조회할 수 있다.")
+    @Test
+    public void test() {
+        // given
+        User user = User.builder()
+            .name("황성찬")
+            .userRole(UserRole.USER)
+            .profileImageUrl("http://naver.com/test.png")
+            .email("fusis1@naver.com")
+            .build();
+        userRepository.save(user);
+
+        String expected = "";
+        Folder folder = Folder.builder()
+            .title(expected)
+            .build();
+        folderRepository.save(folder);
+        user.addFolder(folder);
+
+        // when
+        String actual = folderRepository.findFirstByUserIdAndTitle(user.getId(), folder.getTitle())
+            .get().getTitle();
+
+        // then
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/com/undertheriver/sgsg/memo/service/MemoServiceTest.java
+++ b/src/test/java/com/undertheriver/sgsg/memo/service/MemoServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.undertheriver.sgsg.common.exception.BadRequestException;
+import com.undertheriver.sgsg.common.exception.FolderValidationException;
 import com.undertheriver.sgsg.common.exception.ModelNotFoundException;
 import com.undertheriver.sgsg.common.type.UserRole;
 import com.undertheriver.sgsg.foler.domain.Folder;
@@ -112,6 +113,35 @@ class MemoServiceTest {
         Long expectedFolderId = folderService.read(actualFolderId).getId();
 
         assertEquals(expectedFolderId, actualFolderId);
+    }
+
+    @DisplayName("메모 생성 시 폴더가 없을 때 폴더 이름은 중복 생성될 수 없다.")
+    @Test
+    public void create2() {
+        // given
+        Folder folder = Folder.builder()
+            .title(createFolderReq1.getTitle())
+            .color(FolderColor.BLUE)
+            .user(user)
+            .build();
+        folderRepository.save(folder);
+        user.addFolder(folder);
+
+        createMemoNoFolderReq1 = MemoDto.CreateMemoReq.builder()
+            .folderTitle(createFolderReq1.getTitle())
+            .folderColor(createFolderReq1.getColor())
+            .memoContent(FOLDER_TITLE_TEST)
+            .build();
+
+        // when
+        FolderValidationException actual = assertThrows(
+            FolderValidationException.class,
+            () -> memoService.save(user.getId(), createMemoNoFolderReq1)
+        );
+
+
+        // then
+        assertEquals(FolderValidationException.DUPLICATE_FOLDER_NAME, actual.getMessage());
     }
 
     @DisplayName("메모를 수정할 수 있다.")


### PR DESCRIPTION
#142

## 변경 사항
- 폴더 생성 시 폴더 이름을 중복 검사합니다.
- 메모 생성 시 폴더를 생성하는 케이스에도 폴더 이름을 중복 검사합니다.
- FolderValidationException을 추가했습니다.

## 기타
- 폴더 이름 컬럼 인덱스는 [feat: 인덱스 추가 및 네이밍 변경](https://github.com/DDD-5/undertheriver-sgsg-backend/pull/138) PR에 작업해두겠습니다.
- 중복 검사를 위해서 쿼리 메서드를 추가 했는데 그냥 폴더 이름 컬럼에 유니크를 설정해도 됐을까 싶네요.

