### PR TITLE
feat: 유저와 폴더의 객체 관계를 제거 한다.

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -5,10 +5,12 @@ import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -31,8 +33,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(indexes = {
-    @Index(name = "folder_idx_user", columnList = "user"),
-    @Index(name = "folder_idx_user_title", columnList = "user, title")
+    @Index(name = "folder_idx_user", columnList = "userId"),
+    @Index(name = "folder_idx_user_title", columnList = "userId, title")
 })
 @Entity
 @Getter
@@ -47,9 +49,13 @@ public class Folder extends BaseEntity {
     private String title;
     @Enumerated(EnumType.STRING)
     private FolderColor color;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user")
-    private User user;
+
+    @ManyToOne(
+        targetEntity = User.class,
+        cascade = CascadeType.ALL,
+        optional = false
+    )
+    private Long userId;
     private Boolean secret;
 
     public boolean isSecret() {
@@ -57,10 +63,10 @@ public class Folder extends BaseEntity {
     }
 
     @Builder
-    public Folder(String title, FolderColor color, User user) {
+    public Folder(String title, FolderColor color, Long userId) {
         this.title = title;
         this.color = color;
-        this.user = user;
+        this.userId = userId;
     }
 
     public void update(FolderDto.UpdateFolderTitleReq dto) {
@@ -72,10 +78,6 @@ public class Folder extends BaseEntity {
         memo.mapFolder(this);
     }
 
-    public void mapUser(User user) {
-        this.user = user;
-    }
-
     public void secret() {
         secret = true;
     }
@@ -85,7 +87,7 @@ public class Folder extends BaseEntity {
     }
 
     public boolean hasBy(Long userId) {
-        return user.getId().equals(userId);
+        return this.userId.equals(userId);
     }
 
     @Override

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/Folder.java
@@ -50,11 +50,6 @@ public class Folder extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FolderColor color;
 
-    @ManyToOne(
-        targetEntity = User.class,
-        cascade = CascadeType.ALL,
-        optional = false
-    )
     private Long userId;
     private Boolean secret;
 

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderColor.java
@@ -13,9 +13,10 @@ public enum FolderColor {
         this.colorCode = colorCode;
     }
 
-    public static FolderColor getNextColor(int folderRowSize) {
-        FolderColor[] values = FolderColor.values();
-        int nextColorOrdinary = folderRowSize % FolderColor.values().length;
-        return values[nextColorOrdinary];
+    public static FolderColor nextColorFrom(int folderRowSize) {
+        FolderColor[] colors = FolderColor.values();
+        int next = folderRowSize % colors.length;
+        return colors[next];
     }
+
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/dto/FolderDto.java
@@ -15,17 +15,20 @@ public class FolderDto {
     public static class CreateFolderReq {
         private String title;
         private FolderColor color;
+        private Long userId;
 
         @Builder
-        public CreateFolderReq(String title, FolderColor color) {
+        public CreateFolderReq(String title, FolderColor color, Long userId) {
             this.title = title;
             this.color = color;
+            this.userId = userId;
         }
 
         public Folder toEntity() {
             return Folder.builder()
                 .title(this.title)
                 .color(this.color)
+                .userId(this.userId)
                 .build();
         }
     }

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -14,7 +14,7 @@ import com.undertheriver.sgsg.foler.domain.Folder;
 public interface FolderRepository extends JpaRepository<Folder, Long> {
     @Query(value = "SELECT f FROM Folder f "
         + "JOIN f.memos "
-        + "WHERE f.user.id = :userId "
+        + "WHERE f.userId = :userId "
         + "GROUP BY f.id "
         + "ORDER BY count(f.id) DESC")
     List<Folder> findAllOrderByMemos(Long userId);

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -55,7 +55,6 @@ public class FolderService {
         User user = userRepository.findById(userId)
             .orElseThrow(ModelNotFoundException::new);
         Folder folder = folderRepository.save(req.toEntity());
-        user.addFolder(folder);
         return folder.getId();
     }
 
@@ -105,7 +104,7 @@ public class FolderService {
     @Transactional(readOnly = true)
     public FolderDto.GetNextFolderColorRes getNextColor(Long userId) {
         Integer folderCount = folderRepository.countByUserId(userId);
-        FolderColor nextColor = FolderColor.getNextColor(folderCount);
+        FolderColor nextColor = FolderColor.nextColorFrom(folderCount);
         return FolderDto.GetNextFolderColorRes.builder()
             .nextColor(nextColor)
             .build();

--- a/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/domain/Memo.java
@@ -92,9 +92,7 @@ public class Memo extends BaseEntity {
     }
 
     public boolean hasBy(Long userId) {
-        return !folder.getUser()
-            .getId()
-            .equals(userId);
+        return folder.hasBy(userId);
     }
 
     public String fetchContent() {

--- a/src/main/java/com/undertheriver/sgsg/memo/repository/MemoRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/repository/MemoRepository.java
@@ -12,7 +12,7 @@ import com.undertheriver.sgsg.memo.domain.Memo;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     @Query(value = "SELECT m FROM Memo m "
-        + "JOIN Folder f ON f.user.id = :userId "
+        + "JOIN Folder f ON f.userId = :userId "
         + "WHERE f.id = m.folder.id "
         + "ORDER BY m.favorite DESC, m.createdAt DESC ")
     List<Memo> findAllByUser(Long userId);

--- a/src/main/java/com/undertheriver/sgsg/memo/service/MemoService.java
+++ b/src/main/java/com/undertheriver/sgsg/memo/service/MemoService.java
@@ -37,7 +37,6 @@ public class MemoService {
         Folder folder = createOrReadFolder(userId, body);
         User user = userRepository.findById(userId)
             .orElseThrow(ModelNotFoundException::new);
-        user.addFolder(folder);
         Memo memo = memoRepository.save(body.toMemoEntity());
         folder.addMemo(memo);
         return memo.getId();
@@ -116,7 +115,7 @@ public class MemoService {
     }
 
     private void validateUserHasMemo(Long userId, Memo memo) {
-        if (memo.hasBy(userId)) {
+        if (!memo.hasBy(userId)) {
             throw new BadRequestException(UNMACHED_USER);
         }
     }

--- a/src/main/java/com/undertheriver/sgsg/user/domain/User.java
+++ b/src/main/java/com/undertheriver/sgsg/user/domain/User.java
@@ -38,8 +38,7 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private final List<UserApiClient> userApiClients = new ArrayList<>();
-    @OneToMany(mappedBy = "user")
-    private final List<Folder> folders = new ArrayList<>();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -79,11 +78,6 @@ public class User extends BaseEntity {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         return this;
-    }
-
-    public void addFolder(Folder folder) {
-        this.folders.add(folder);
-        folder.mapUser(this);
     }
 
     public Boolean hasFolderPassword() {

--- a/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/repository/FolderRepositoryTest.java
@@ -25,7 +25,7 @@ public class FolderRepositoryTest {
     @Autowired
     private FolderRepository folderRepository;
 
-    @DisplayName("유저가 가진 폴더 중 제목이 일치하는 가장 첫 번째 폴더를 조회할 수 있다.")
+    @DisplayName("유저는 폴더 중 제목이 일치하는 가장 첫 번째 폴더를 조회할 수 있다.")
     @Test
     public void test() {
         // given
@@ -36,16 +36,17 @@ public class FolderRepositoryTest {
             .email("fusis1@naver.com")
             .build();
         userRepository.save(user);
+        Long userId = user.getId();
 
         String expected = "";
         Folder folder = Folder.builder()
             .title(expected)
+            .userId(userId)
             .build();
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         // when
-        String actual = folderRepository.findFirstByUserIdAndTitle(user.getId(), folder.getTitle())
+        String actual = folderRepository.findFirstByUserIdAndTitle(userId, folder.getTitle())
             .get().getTitle();
 
         // then

--- a/src/test/java/com/undertheriver/sgsg/foler/service/FolderServiceTest.java
+++ b/src/test/java/com/undertheriver/sgsg/foler/service/FolderServiceTest.java
@@ -50,12 +50,11 @@ class FolderServiceTest {
         // given
         User user = createUser("1234");
         userRepository.save(user);
+        Long userId = user.getId();
 
-        Folder moreMemoFolder = createFolder("테스트 폴더");
-        Folder lessMemoFolder = createFolder("테스트 폴더2");
+        Folder moreMemoFolder = createFolder("테스트 폴더", userId);
+        Folder lessMemoFolder = createFolder("테스트 폴더2", userId);
         folderRepository.saveAll(Arrays.asList(moreMemoFolder, lessMemoFolder));
-        user.addFolder(moreMemoFolder);
-        user.addFolder(lessMemoFolder);
 
         Memo memo1 = createMemo("메모1", null);
         Memo memo2 = createMemo("메모2", null);
@@ -81,13 +80,11 @@ class FolderServiceTest {
         // given
         User user = createUser("1234");
         userRepository.save(user);
+        Long userId = user.getId();
 
-        Folder folder1 = createFolder("가나다");
-        Folder folder2 = createFolder("다나가");
+        Folder folder1 = createFolder("가나다", userId);
+        Folder folder2 = createFolder("다나가", userId);
         folderRepository.saveAll(Arrays.asList(folder1, folder2));
-        user.addFolder(folder1);
-        user.addFolder(folder2);
-
         String expectedTitle = folder1.getTitle();
 
         // when
@@ -104,13 +101,11 @@ class FolderServiceTest {
         // given
         User user = createUser("1234");
         userRepository.save(user);
+        Long userId = user.getId();
 
-        Folder folder1 = createFolder("가나다");
-        Folder folder2 = createFolder("가나다");
+        Folder folder1 = createFolder("가나다", userId);
+        Folder folder2 = createFolder("가나다", userId);
         folderRepository.saveAll(Arrays.asList(folder1, folder2));
-        user.addFolder(folder1);
-        user.addFolder(folder2);
-
         Long expectedFolderId = folder1.getId();
 
         // when
@@ -127,13 +122,13 @@ class FolderServiceTest {
         // given
         User user = createUser("1234");
         userRepository.save(user);
+        Long userId = user.getId();
 
         List<Folder> folderList = new ArrayList<>();
         for (int i = 0; i < 21; i++) {
-            folderList.add(createFolder("테스트 폴더 %d" + i));
+            folderList.add(createFolder(String.format("테스트 폴더 %d", i), userId));
         }
         folderRepository.saveAll(folderList);
-        folderList.forEach(user::addFolder);
 
         FolderDto.CreateFolderReq createFolderReq = FolderDto.CreateFolderReq.builder()
             .title("테스트")
@@ -159,9 +154,8 @@ class FolderServiceTest {
         userRepository.save(user);
 
         String folderTitle = "중복";
-        Folder folder = createFolder(folderTitle);
+        Folder folder = createFolder(folderTitle, user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         FolderDto.CreateFolderReq createFolderReq = FolderDto.CreateFolderReq.builder()
             .title(folderTitle)
@@ -182,7 +176,7 @@ class FolderServiceTest {
     @Test
     public void updateFolder() {
         // given
-        Folder folder = createFolder("가나다");
+        Folder folder = createFolder("가나다", null);
         folderRepository.save(folder);
 
         FolderDto.UpdateFolderTitleReq req = FolderDto.UpdateFolderTitleReq.builder()
@@ -197,21 +191,6 @@ class FolderServiceTest {
         assertEquals(expectedTitle, actualTitle);
     }
 
-    @DisplayName("다음 생성할 폴더 색상을 알려준다.")
-    @Test
-    public void nextColorTestCase() {
-        // given
-        FolderColor[] colors = FolderColor.values();
-        FolderColor expectedColor = FolderColor.values()[0];
-        int multipleOfFolderColorLength = colors.length;
-
-        // when
-        FolderColor actualColor = FolderColor.getNextColor(multipleOfFolderColorLength);
-
-        // then
-        assertEquals(actualColor, expectedColor);
-    }
-
     @DisplayName("폴더를 삭제할 수 있다.")
     @Test
     public void delete() {
@@ -219,9 +198,8 @@ class FolderServiceTest {
         User user = createUser("1234");
         userRepository.save(user);
 
-        Folder folder = createFolder("테스트");
+        Folder folder = createFolder("테스트", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         // when
         folderService.delete(folder.getId());
@@ -237,9 +215,8 @@ class FolderServiceTest {
         User user = createUser("1234");
         userRepository.save(user);
 
-        Folder folder = createFolder("테스트");
+        Folder folder = createFolder("테스트", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         // when
         folderService.secret(user.getId(), folder.getId());
@@ -256,9 +233,8 @@ class FolderServiceTest {
         User user = createUser(rawPassword);
         userRepository.save(user);
 
-        Folder folder = createFolder("테스트 폴더");
+        Folder folder = createFolder("테스트 폴더", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         FolderDto.UnsecretReq request = new FolderDto.UnsecretReq(rawPassword);
 
@@ -276,9 +252,8 @@ class FolderServiceTest {
         User user = createNoPasswordUser();
         userRepository.save(user);
 
-        Folder folder = createFolder("테스트");
+        Folder folder = createFolder("테스트", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         FolderDto.UnsecretReq request = new FolderDto.UnsecretReq("1234");
 
@@ -300,9 +275,8 @@ class FolderServiceTest {
         User user = createUser("1234");
         userRepository.save(user);
 
-        Folder folder = createFolder("테스트");
+        Folder folder = createFolder("테스트", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         FolderDto.UnsecretReq request = new FolderDto.UnsecretReq("4321");
 
@@ -325,9 +299,8 @@ class FolderServiceTest {
         User user2 = createUser("1234");
         userRepository.saveAll(Arrays.asList(user, user2));
 
-        Folder folder = createFolder("테스트");
+        Folder folder = createFolder("테스트", user.getId());
         folderRepository.save(folder);
-        user.addFolder(folder);
 
         Long wrongUserId = user2.getId();
 
@@ -365,10 +338,11 @@ class FolderServiceTest {
             .build();
     }
 
-    private Folder createFolder(String title) {
+    private Folder createFolder(String title, Long userId) {
         return Folder.builder()
             .title(title)
             .color(FolderColor.BLUE)
+            .userId(userId)
             .build();
     }
 

--- a/src/test/java/com/undertheriver/sgsg/memo/repository/MemoRepositoryTest.java
+++ b/src/test/java/com/undertheriver/sgsg/memo/repository/MemoRepositoryTest.java
@@ -77,7 +77,7 @@ class MemoRepositoryTest {
 
     private Folder createFolder(User user) {
         return Folder.builder()
-            .user(user)
+            .userId(user.getId())
             .title("안녕")
             .build();
     }

--- a/src/test/java/com/undertheriver/sgsg/user/domain/FolderColorTest.java
+++ b/src/test/java/com/undertheriver/sgsg/user/domain/FolderColorTest.java
@@ -1,0 +1,24 @@
+package com.undertheriver.sgsg.user.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.undertheriver.sgsg.foler.domain.FolderColor;
+
+public class FolderColorTest {
+    @DisplayName("다음 생성할 폴더 색상을 알려준다.")
+    @Test
+    public void nextColorTestCase() {
+        // given
+        FolderColor[] colors = FolderColor.values();
+        FolderColor expectedColor = colors[0];
+
+        // when
+        FolderColor actualColor = FolderColor.nextColorFrom(colors.length);
+
+        // then
+        assertEquals(actualColor, expectedColor);
+    }
+}


### PR DESCRIPTION
#82

## 변경 사항
- 유저와 폴더의 코드 레벨(객체) 관계를 제거 했습니다.
- 이제 유저 객체는 폴더 객체를 알지 못하고 폴더 객체는 유저의 ID만 알고 있습니다.
- [유저에서 폴더 제거 커밋](https://github.com/DDD-5/undertheriver-sgsg-backend/pull/183/commits/f15c8406706737236b1eef548ee736c4d30f6fe6)과  [폴더에서 유저 객체 제거 커밋](https://github.com/DDD-5/undertheriver-sgsg-backend/pull/183/commits/dfb27365466df9b833439f4bf650089a6e849c8b)이 직접적으로 도메인이 변경된 커밋입니다.
- 뜬금없이 [FolderColor 의 코드도 리팩토링](https://github.com/DDD-5/undertheriver-sgsg-backend/pull/183/commits/a235b54d72bb04bb9ce4923bd43f55e02196a54c) 했습니다. 리뷰 부탁드립니다.
- [마지막 커밋](https://github.com/DDD-5/undertheriver-sgsg-backend/pull/183/commits/0f531cb962760f72aaaccb3b122e87a192f6d9f0)이 하나 있긴 한데 관계를 매핑하던 `user.addFolder()` 메서드들을 제거한 코드입니다. 가볍게 보셔도 될 것 같아요

## 기타
- 폴더의 유저ID에 인덱스는 걸려있는데 외래키는 걸려있지 않습니다.
- JPA에서 외래키만 설정할 수 있는 방법이 있는지 모르겠습니다.
- `@ForeignKey`, `@ManyToOne` 을 단독으로 사용해봤는데 안되더라구요 ㅎㅎ..