### PR TITLE
refactor: FolderOrderBy 와 FolderRepository 의존성 제거

### DIFF
--- a/src/main/java/com/undertheriver/sgsg/foler/domain/FolderOrderBy.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/domain/FolderOrderBy.java
@@ -10,29 +10,30 @@ import org.springframework.data.domain.Sort;
 import com.undertheriver.sgsg.foler.repository.FolderRepository;
 
 public enum FolderOrderBy {
-    NAME(Sort.by(Sort.Direction.ASC, "title")),
-    CREATED_AT(Sort.by(Sort.Direction.ASC, "createdAt")),
-    MEMO(Sort.by(Sort.Direction.ASC, "createdAt"));
-
-    protected final Sort sort;
-
-    FolderOrderBy(Sort sort) {
-        this.sort = sort;
-    }
-
-    public List<Folder> findFolders(Long userId, FolderRepository folderRepository) {
-        switch (this) {
-            case NAME:
-            case CREATED_AT:
-                return folderRepository.findAllByUser(userId, sort);
-            case MEMO:
-                return folderRepository.findAllByUser(userId, sort)
-                    .stream()
-                    .sorted((p1, p2) -> Integer.compare(p2.getMemos().size(), p1.getMemos().size()))
-                    .collect(Collectors.toList());
-
-            default:
-                return Arrays.asList(new Folder());
+    DEFAULT {
+        @Override
+        public Sort getSort() {
+            return Sort.by(Sort.Direction.ASC, "createdAt");
         }
-    }
+    },
+    NAME {
+        @Override
+        public Sort getSort() {
+            return Sort.by(Sort.Direction.ASC, "title");
+        }
+    },
+    CREATED_AT {
+        @Override
+        public Sort getSort() {
+            return Sort.by(Sort.Direction.ASC, "createdAt");
+        }
+    },
+    MEMO {
+        @Override
+        public Sort getSort() {
+            return Sort.by(Sort.Direction.ASC, "createdAt");
+        }
+    };
+
+    abstract public Sort getSort();
 }

--- a/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/repository/FolderRepository.java
@@ -12,12 +12,6 @@ import com.undertheriver.sgsg.foler.domain.Folder;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-    @Query(value = "SELECT f FROM Folder f "
-        + "JOIN f.memos "
-        + "WHERE f.user = :userId "
-        + "GROUP BY f.id "
-        + "ORDER BY count(f.id) DESC")
-    List<Folder> findAllOrderByMemos(Long userId);
 
     List<Folder> findAllByUser(Long userId, Sort sort);
 

--- a/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
+++ b/src/main/java/com/undertheriver/sgsg/foler/service/FolderService.java
@@ -5,6 +5,7 @@ import static com.undertheriver.sgsg.common.exception.FolderValidationException.
 import static com.undertheriver.sgsg.user.exception.PasswordValidationException.*;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -76,12 +77,11 @@ public class FolderService {
     }
 
     public List<FolderDto.ReadFolderRes> readAll(Long userId, FolderOrderBy orderBy) {
-        if (orderBy == null) {
-            orderBy = FolderOrderBy.CREATED_AT;
+        if (Objects.isNull(orderBy)) {
+            orderBy = FolderOrderBy.DEFAULT;
         }
 
-        return orderBy.findFolders(userId, folderRepository)
-            .stream()
+        return folderRepository.findAllByUser(userId, orderBy.getSort()).stream()
             .map(FolderDto.ReadFolderRes::toDto)
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
#

## 변경 사항
- FolderOrderBy 라는 Enum 클래스가 FolderRepository 를 사용하던 로직을 개선했습니다.
- 이제는 FolderOrderBy 클래스에서 Sort 를 직접 리턴합니다.

## 기타
- FolderOrderBy에서 Sort를 직접 리턴하는 것을 개선할 수 없을까 고민해야겠습니다.
- 또, Sort 기준이 늘어날 때 마다(FolderOrderBy에 상수가 추가될 때 마다)  작업을 해줘야하는 상황인데 이것을 개선할 수 없을까 고민해야겠습니다.

